### PR TITLE
Fix TypeScript type parsing error and clean up logs

### DIFF
--- a/.changeset/big-weeks-shave.md
+++ b/.changeset/big-weeks-shave.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/type-parser": patch
+---
+
+Fixed error when trying to parse TypeScript types

--- a/demo/custom-elements.json
+++ b/demo/custom-elements.json
@@ -129,6 +129,39 @@
               }
             },
             {
+              "kind": "field",
+              "name": "variant",
+              "type": {
+                "text": "Variant"
+              },
+              "default": "\"primary\"",
+              "parsedType": {
+                "text": "'primary' | 'secondary' | 'tertiary'"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "foobar",
+              "type": {
+                "text": "{ [key: string]: any }"
+              },
+              "default": "{ foo: 'bar' }"
+            },
+            {
+              "kind": "field",
+              "name": "complexObject",
+              "type": {
+                "text": "PositionPopoverOptions"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "omitType",
+              "type": {
+                "text": "MyOmitType"
+              }
+            },
+            {
               "kind": "method",
               "name": "render"
             }

--- a/demo/src/my-component.ts
+++ b/demo/src/my-component.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { Test2 } from "./alt-types";
 import type { Test } from "./types";
@@ -21,6 +22,32 @@ enum DirectionEnum {
 }
 type DirectionOptions = keyof typeof DirectionEnum;
 
+type Alignment = 'start' | 'end';
+type Side = 'top' | 'right' | 'bottom' | 'left';
+type AlignedPlacement = `${Side}-${Alignment}`;
+
+export type PopoverPosition = Side | AlignedPlacement;
+
+export interface PositionPopoverOptions {
+  arrowElement?: string | HTMLElement;
+  anchorElement?: string | HTMLAnchorElement;
+  arrowPadding?: number;
+  maxWidth?: number;
+  offset?: number;
+  position?: PopoverPosition;
+  viewportMargin?: number;
+  rootMarginTop?: number;
+}
+
+export type AnchorControllerConfig = PositionPopoverOptions;
+
+export interface ButtonProps {
+  variant: 'primary' | 'secondary' | 'tertiary'
+  size: 'sm' | 'md' | 'lg'
+}
+
+type Variant = ButtonProps['variant'];
+
 /**
  * Test component
  *
@@ -40,6 +67,10 @@ export class MyComponent extends HTMLElement {
   namedUnion: UnionType;
   direction: DirectionOptions;
   enumExample: DirectionEnum;
+  variant: Variant = "primary";
+  foobar: { [key: string]: any } = { foo: 'bar' }
+  complexObject: PositionPopoverOptions;
+  omitType: MyOmitType;
 
   constructor() {
     super();

--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -172,10 +172,8 @@ function getObjectTypes(fileName: string, typeName: string): string {
 
 function getFinalType(type: any): string {
   if(isTsType(type)) {
-    console.log("HTMLElement detected", type.flags, typeChecker.typeToString(type));
     return typeChecker.typeToString(type);
   }
-
   if (type.isUnion()) {
     return type.types.map(getFinalType).join(" | ");
   }

--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -171,6 +171,11 @@ function getObjectTypes(fileName: string, typeName: string): string {
 }
 
 function getFinalType(type: any): string {
+  if(isTsType(type)) {
+    console.log("HTMLElement detected", type.flags, typeChecker.typeToString(type));
+    return typeChecker.typeToString(type);
+  }
+
   if (type.isUnion()) {
     return type.types.map(getFinalType).join(" | ");
   }
@@ -231,8 +236,6 @@ function getFinalType(type: any): string {
     return enumValues.join(" | ");
   }
 
-  // Add more type checks as needed
-
   // Get properties if the type is an object
   if (type.isClassOrInterface() || type.flags & typeScript.TypeFlags.Object) {
     const properties = typeChecker.getPropertiesOfType(type);
@@ -250,6 +253,19 @@ function getFinalType(type: any): string {
   }
 
   return typeChecker.typeToString(type);
+}
+
+function isTsType(type: ts.Type): boolean {
+  const symbol = type.getSymbol();
+  if (!symbol) return false;
+
+  const declarations = symbol.getDeclarations();
+  if (!declarations || declarations.length === 0) return false;
+
+  return declarations.some((decl) => {
+    const sourceFile = decl.getSourceFile();
+    return sourceFile.fileName.includes('node_modules/typescript');
+  });
 }
 
 // Visit each node in the source file


### PR DESCRIPTION
Resolve an error encountered when parsing TypeScript types and remove unnecessary logs for cleaner code.