### PR TITLE
Exclude node_modules from parser

### DIFF
--- a/.changeset/lemon-pears-attack.md
+++ b/.changeset/lemon-pears-attack.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/type-parser": patch
+---
+
+Excluded `mode_modules` from parser to prevent infinite loops

--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -171,7 +171,7 @@ function getObjectTypes(fileName: string, typeName: string): string {
 }
 
 function getFinalType(type: any): string {
-  if(isTsType(type)) {
+  if(isNpmType(type)) {
     return typeChecker.typeToString(type);
   }
   if (type.isUnion()) {
@@ -253,7 +253,7 @@ function getFinalType(type: any): string {
   return typeChecker.typeToString(type);
 }
 
-function isTsType(type: ts.Type): boolean {
+function isNpmType(type: ts.Type): boolean {
   const symbol = type.getSymbol();
   if (!symbol) return false;
 
@@ -262,7 +262,7 @@ function isTsType(type: ts.Type): boolean {
 
   return declarations.some((decl) => {
     const sourceFile = decl.getSourceFile();
-    return sourceFile.fileName.includes('node_modules/typescript');
+    return sourceFile.fileName.includes('node_modules');
   });
 }
 


### PR DESCRIPTION
Prevent infinite loops by excluding `node_modules` from the parser logic. Adjusted type-checking functions to reflect this change.