### PR TITLE
Add option for parsing method parameter types

### DIFF
--- a/.changeset/funny-jokes-tan.md
+++ b/.changeset/funny-jokes-tan.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/type-parser": minor
+---
+
+Add config option for parsing method parameters

--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -391,7 +391,7 @@ function getTypedMembers(component: Component) {
       ...(component.members || []),
       ...(component.events || []),
     ] as any[]
-  ).filter((item) => item?.type);
+  ).filter((item) => item?.type || item?.parameters?.type);
 }
 
 function getTypeValue(item: any, context: any) {
@@ -436,11 +436,15 @@ function updateParsedTypes(component: Component, context: any) {
   const propName = options.propertyName || "parsedType";
 
   typedMembers.forEach((member) => {
-    const typeValue = getTypeValue(member, context);
-    if (typeValue !== member.type.text) {
-      member[propName] = {
-        text: typeValue.replace(/"/g, "'"),
-      };
+    if (member.kind === "method" && member.parameters?.length > 0) {
+      // TODO: member.parameters.forEach();
+    } else {
+      const typeValue = getTypeValue(member, context);
+      if (typeValue !== member.type.text) {
+        member[propName] = {
+          text: typeValue.replace(/"/g, "'"),
+        };
+      }
     }
   });
 }

--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -11,6 +11,8 @@ export type ParseObjectTypesMode = 'none' | 'partial' | 'full';
 export interface Options {
   /** Controls whether object types are parsed, and if so, whether fully or partially ('none', 'partial', 'full') */
   parseObjectTypes?: ParseObjectTypesMode;
+  /** Controls whether method parameters are parsed */
+  parseParameters?: boolean;
   /** Determines the name of the property used in the manifest to store the parsed type */
   propertyName?: string;
   /** Shows output logs used for debugging */
@@ -51,6 +53,7 @@ let tsConfigFile: any;
 let log: Logger;
 const defaultOptions: Options = {
   parseObjectTypes: "none",
+  parseParameters: false,
   propertyName: "parsedType",
 };
 
@@ -391,7 +394,7 @@ function getTypedMembers(component: Component) {
       ...(component.members || []),
       ...(component.events || []),
     ] as any[]
-  ).filter((item) => item?.type || item?.parameters?.type);
+  ).filter((item) => item?.type || (options.parseParameters && item?.parameters?.length));
 }
 
 function getTypeValue(item: any, context: any) {
@@ -436,8 +439,8 @@ function updateParsedTypes(component: Component, context: any) {
   const propName = options.propertyName || "parsedType";
 
   typedMembers.forEach((member) => {
-    if (member.kind === "method" && member.parameters?.length > 0) {
-      member.parameters.forEach((param: any, i: number) => {
+    if (member.parameters?.length) {
+      member.parameters.forEach((param, i) => {
         if (param.type?.text) {
           const typeValue = getTypeValue(param, context);
           if (typeValue !== param.type.text) {

--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -437,7 +437,16 @@ function updateParsedTypes(component: Component, context: any) {
 
   typedMembers.forEach((member) => {
     if (member.kind === "method" && member.parameters?.length > 0) {
-      // TODO: member.parameters.forEach();
+      member.parameters.forEach((param: any, i: number) => {
+        if (param.type?.text) {
+          const typeValue = getTypeValue(param, context);
+          if (typeValue !== param.type.text) {
+            member.parameters[i][propName] = {
+              text: typeValue.replace(/"/g, "'"),
+            };
+          }
+        }
+      });
     } else {
       const typeValue = getTypeValue(member, context);
       if (typeValue !== member.type.text) {


### PR DESCRIPTION
This PR adds a new config option, `parseParameters` (boolean), false by default, but if set to true, will also parse method parameters.