### PR TITLE
Bugfix: Add type information to new forEach arguments

### DIFF
--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -440,7 +440,7 @@ function updateParsedTypes(component: Component, context: any) {
 
   typedMembers.forEach((member) => {
     if (member.parameters?.length) {
-      member.parameters.forEach((param, i) => {
+      member.parameters.forEach((param: any, i: number) => {
         if (param.type?.text) {
           const typeValue = getTypeValue(param, context);
           if (typeValue !== param.type.text) {


### PR DESCRIPTION
In #16, after merge, a build process failed ([see here](https://github.com/wc-toolkit/type-parser/actions/runs/16681384316/job/47220630538)) pointing out a couple of missing types - the arguments for a new `forEach` that was added to support the new method parameter type parsing feature. This PR adds the necessary type information so that build step will no longer fail.