### PR TITLE
Add safer fallbacks for complex type parsing

### DIFF
--- a/.changeset/tidy-geckos-invent.md
+++ b/.changeset/tidy-geckos-invent.md
@@ -1,0 +1,7 @@
+---
+"@wc-toolkit/type-parser": patch
+---
+
+Improve type parsing fallbacks for complex and recursive aliases.
+
+The parser now preserves manifest generation by warning and falling back to the original type text when a type cannot be safely expanded, and it resolves more object-based utility types such as `Omit`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Using type aliases to define the types for your component’s APIs, can be helpful for keeping your code clean and organized as well as making your types reusable.
 
-The down-side is that it can be difficult to integrate with other tooling or communicate in documentation what the available options are. 
+The down-side is that it can be difficult to integrate with other tooling or communicate in documentation what the available options are.
 This plugin parses the types so they available in a more usable format.
 
 ## Installation
@@ -24,7 +24,7 @@ Using type aliases to define the types for your component's APIs, can be helpful
 ```ts
 // my-component.ts
 
-type Target = '_blank' | '_self' | '_parent' | '_top';
+type Target = "_blank" | "_self" | "_parent" | "_top";
 
 class MyLink extends HTMLElement {
   target?: Target;
@@ -32,6 +32,8 @@ class MyLink extends HTMLElement {
 ```
 
 This plugin parses the types for your component APIs in Custom Elements Manifest using the [Custom Element Manifest Analyzer](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/).
+
+If a type cannot be safely expanded, such as a recursive or overly complex external type, the plugin keeps the original type text and logs a warning with the type name, declaration location, and reason it was skipped.
 
 ```js
 // custom-elements-manifest.config.js

--- a/demo/custom-elements.json
+++ b/demo/custom-elements.json
@@ -159,6 +159,9 @@
               "name": "omitType",
               "type": {
                 "text": "MyOmitType"
+              },
+              "parsedType": {
+                "text": "{ prop1: string }"
               }
             },
             {

--- a/src/__fixtures__/recursive-types.ts
+++ b/src/__fixtures__/recursive-types.ts
@@ -1,0 +1,9 @@
+import type { Node } from "typescript";
+
+type RecursiveLocal = {
+  next?: RecursiveLocal;
+  label: string;
+};
+
+export type RecursiveLocalAlias = RecursiveLocal;
+export type ExternalNodeAlias = Node;

--- a/src/__tests__/cem-plugin.test.ts
+++ b/src/__tests__/cem-plugin.test.ts
@@ -1,114 +1,136 @@
 import path from "path";
-import { describe, expect, test } from "vitest";
-import cem from '../../demo/custom-elements.json' with { type: 'json' };
-import { getComponentByClassName, getComponentPublicProperties } from "@wc-toolkit/cem-utilities";
+import ts from "typescript";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import cem from "../../demo/custom-elements.json" with { type: "json" };
+import {
+  getComponentByClassName,
+  getComponentPublicProperties,
+} from "@wc-toolkit/cem-utilities";
 import { Property } from "@wc-toolkit/cem-utilities";
-import { typeParserPlugin } from "../cem-plugin.js";
+import { getTsProgram, typeParserPlugin } from "../cem-plugin.js";
 
-
-describe('type-parser', () => {
-  type Prop = Property<Record<string, unknown> & { parsedType?: { text: string } }>;
-  const component = getComponentByClassName(cem, 'MyComponent');
+describe("type-parser", () => {
+  type Prop = Property<
+    Record<string, unknown> & { parsedType?: { text: string } }
+  >;
+  const component = getComponentByClassName(cem, "MyComponent");
   const properties = getComponentPublicProperties<Prop>(component!);
+  const fixturePath = path.resolve("src/__fixtures__/recursive-types.ts");
 
-  test('should not create parsed types for JS primitive types', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("should not create parsed types for JS primitive types", () => {
     // Arrange
-    const name = properties.find(p => p.name === 'name');
-    const age = properties.find(p => p.name === 'age');
-    const active = properties.find(p => p.name === 'active');
-    
+    const name = properties.find((p) => p.name === "name");
+    const age = properties.find((p) => p.name === "age");
+    const active = properties.find((p) => p.name === "active");
+
     // Act
-    
+
     // Assert
     expect(name?.parsedType?.text).toBeUndefined();
     expect(age?.parsedType?.text).toBeUndefined();
     expect(active?.parsedType?.text).toBeUndefined();
   });
 
-  test('should resolve types in same file', () => {
+  test("should resolve types in same file", () => {
     // Arrange
-    const internal = properties.find(p => p.name === 'internal');
-    
+    const internal = properties.find((p) => p.name === "internal");
+
     // Act
-    
+
     // Assert
     expect(internal?.parsedType?.text).toEqual("'sports' | 'music' | 'art'");
   });
 
-  test('should resolve types from external .ts file', () => {
+  test("should resolve types from external .ts file", () => {
     // Arrange
-    const tsExternal = properties.find(p => p.name === 'tsExternal');
-    
+    const tsExternal = properties.find((p) => p.name === "tsExternal");
+
     // Act
-    
+
     // Assert
-    expect(tsExternal?.parsedType?.text).toEqual("'value4' | 'value5' | 'value6'");
+    expect(tsExternal?.parsedType?.text).toEqual(
+      "'value4' | 'value5' | 'value6'",
+    );
   });
 
-  test('should resolve types from external .d.ts file', () => {
+  test("should resolve types from external .d.ts file", () => {
     // Arrange
-    const dtsExternal = properties.find(p => p.name === 'dtsExternal');
-    
+    const dtsExternal = properties.find((p) => p.name === "dtsExternal");
+
     // Act
-    
+
     // Assert
-    expect(dtsExternal?.parsedType?.text).toEqual("'value1' | 'value2' | 'value3'");
+    expect(dtsExternal?.parsedType?.text).toEqual(
+      "'value1' | 'value2' | 'value3'",
+    );
   });
 
-  test('should resolve types for generic type', () => {
+  test("should resolve types for generic type", () => {
     // Arrange
-    const generic = properties.find(p => p.name === 'generic');
-    
+    const generic = properties.find((p) => p.name === "generic");
+
     // Act
-    
+
     // Assert
-    expect(generic?.parsedType?.text).toEqual("'value1' | 'value2' | 'value3' | 'sports' | 'music' | 'art'");
+    expect(generic?.parsedType?.text).toEqual(
+      "'value1' | 'value2' | 'value3' | 'sports' | 'music' | 'art'",
+    );
   });
 
-  test('should resolve types for Exclude utility type', () => {
+  test("should resolve types for Exclude utility type", () => {
     // Arrange
-    const exclude = properties.find(p => p.name === 'exclude');
-    
+    const exclude = properties.find((p) => p.name === "exclude");
+
     // Act
-    
+
     // Assert
-    expect(exclude?.parsedType?.text).toEqual("'value4' | 'value5' | 'value6' | 'value2' | 'value3'");
+    expect(exclude?.parsedType?.text).toEqual(
+      "'value4' | 'value5' | 'value6' | 'value2' | 'value3'",
+    );
   });
 
-  test('should resolve types for named union type', () => {
+  test("should resolve types for named union type", () => {
     // Arrange
-    const namedUnion = properties.find(p => p.name === 'namedUnion');
-    
+    const namedUnion = properties.find((p) => p.name === "namedUnion");
+
     // Act
-    
+
     // Assert
-    expect(namedUnion?.parsedType?.text).toEqual("'value4' | 'value5' | 'value6' | 'value1' | 'value2' | 'value3'");
+    expect(namedUnion?.parsedType?.text).toEqual(
+      "'value4' | 'value5' | 'value6' | 'value1' | 'value2' | 'value3'",
+    );
   });
 
-  test('should resolve types for enum keys', () => {
+  test("should resolve types for enum keys", () => {
     // Arrange
-    const direction = properties.find(p => p.name === 'direction');
-    
+    const direction = properties.find((p) => p.name === "direction");
+
     // Act
-    
+
     // Assert
-    expect(direction?.parsedType?.text).toEqual("'Up' | 'Down' | 'Left' | 'Right'");
+    expect(direction?.parsedType?.text).toEqual(
+      "'Up' | 'Down' | 'Left' | 'Right'",
+    );
   });
 
-  test('should resolve types for enum', () => {
+  test("should resolve types for enum", () => {
     // Arrange
-    const enumExample = properties.find(p => p.name === 'enumExample');
-    
+    const enumExample = properties.find((p) => p.name === "enumExample");
+
     // Act
-    
+
     // Assert
     expect(enumExample?.parsedType?.text).toEqual("0 | 1 | 2 | 3");
   });
 
-  test('should normalize absolute module paths to relative manifest paths', () => {
+  test("should normalize absolute module paths to relative manifest paths", () => {
     const plugin = typeParserPlugin({});
     const moduleDoc = {
-      path: path.resolve('demo/src/my-component.ts'),
+      path: path.resolve("demo/src/my-component.ts"),
       declarations: [],
     };
 
@@ -119,6 +141,29 @@ describe('type-parser', () => {
       context: {},
     });
 
-    expect(moduleDoc.path).toEqual('demo/src/my-component.ts');
+    expect(moduleDoc.path).toEqual("demo/src/my-component.ts");
+  });
+
+  test("should warn and fall back when a type cannot be safely expanded", () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    typeParserPlugin({ parseObjectTypes: "full" });
+
+    expect(() =>
+      getTsProgram(ts, [fixturePath], "tsconfig.json"),
+    ).not.toThrow();
+
+    const warningOutput = warnSpy.mock.calls
+      .map((args) => args.join(" "))
+      .join("\n");
+    expect(warningOutput).toContain("RecursiveLocal");
+    expect(warningOutput).toContain("src/__fixtures__/recursive-types.ts");
+    expect(warningOutput).toContain("recursive type reference");
+    expect(warningOutput).toContain("Node");
+    expect(warningOutput).toMatch(
+      /node_modules\/typescript\/lib|node_modules\\\\typescript\\\\lib/,
+    );
   });
 });

--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -5,7 +5,7 @@ import { deepMerge, type Component } from "@wc-toolkit/cem-utilities";
 import { Logger } from "./logger.js";
 import type ts from "typescript";
 
-export type ParseObjectTypesMode = 'none' | 'partial' | 'full';
+export type ParseObjectTypesMode = "none" | "partial" | "full";
 
 /** Options for configuring the CEM Type Parser plugin */
 export interface Options {
@@ -27,8 +27,16 @@ interface AliasTypes {
   };
 }
 
+interface ParseContext {
+  depth: number;
+  fallbackText?: string;
+  requestedFileName?: string;
+  visited: WeakSet<object>;
+}
+
 const aliasTypes: AliasTypes = {};
 const groupedTypes: AliasTypes = {};
+const loggedParseFailures = new Set<string>();
 const primitives = [
   "string",
   "number",
@@ -45,12 +53,15 @@ const primitives = [
   "true",
   "false",
 ];
+const MAX_PARSE_DEPTH = 8;
+const MAX_PARSE_PROPERTIES = 50;
+
 let currentFilename = "";
 let typeChecker: any;
 let options: Options;
 let typeScript: typeof import("typescript");
-let tsConfigFile: any;
 let log: Logger;
+
 const defaultOptions: Options = {
   parseObjectTypes: "none",
   parseParameters: false,
@@ -59,11 +70,10 @@ const defaultOptions: Options = {
 
 /**
  * CEM Analyzer plugin to parse types in component metadata
- * @param tc TypeScript type checker
  * @param op Configuration options
  * @returns
  */
-export function typeParserPlugin(op: Options) {
+export function typeParserPlugin(op: Options = {}) {
   options = deepMerge(defaultOptions, op);
   log = new Logger(options.debug);
 
@@ -92,42 +102,96 @@ export function typeParserPlugin(op: Options) {
 export function getTsProgram(
   ts: typeof import("typescript"),
   globs: string[],
-  configName = "tsconfig.json"
+  configName = "tsconfig.json",
 ): ts.Program {
-  tsConfigFile = ts.findConfigFile(
+  options ??= defaultOptions;
+  log ??= new Logger(options.debug);
+  resetParserState();
+
+  const tsConfigFile = ts.findConfigFile(
     process.cwd(),
     ts.sys.fileExists,
-    configName
+    configName,
   );
+  if (!tsConfigFile) {
+    throw new Error(
+      `[type-parser] - Could not find TypeScript config "${configName}".`,
+    );
+  }
   const { config } = ts.readConfigFile(tsConfigFile, ts.sys.readFile);
   const compilerOptions = ts.convertCompilerOptionsFromJson(
     config.compilerOptions ?? {},
-    "."
+    ".",
   );
   const program = ts.createProgram(globs, compilerOptions.options);
   const exclusions =
     config.exclude && config.exclude.length
       ? [...config.exclude, "node_modules"]
       : ["node_modules"];
+
   typeScript = ts;
   typeChecker = program.getTypeChecker();
+
   for (const sourceFile of program.getSourceFiles()) {
     currentFilename = path.resolve(sourceFile.fileName);
-    // exclude files and directories specified in the tsconfig.json including 'node_modules'
     if (!exclusions.some((x: string) => currentFilename.includes(x))) {
       aliasTypes[currentFilename] = {};
       visitNode(sourceFile);
     }
   }
+
   groupTypesByName();
   return program;
+}
+
+function resetParserState() {
+  currentFilename = "";
+
+  for (const key of Object.keys(aliasTypes)) {
+    delete aliasTypes[key];
+  }
+
+  for (const key of Object.keys(groupedTypes)) {
+    delete groupedTypes[key];
+  }
+
+  loggedParseFailures.clear();
 }
 
 function normalizeModulePath(modulePath: string, cwd = process.cwd()) {
   return path.relative(cwd, modulePath).split(path.sep).join("/");
 }
 
-function getParsedType(fileName: string, typeName: string): string {
+function createParseContext(
+  fileName: string,
+  fallbackText?: string,
+  depth = 0,
+  visited = new WeakSet<object>(),
+): ParseContext {
+  return {
+    depth,
+    fallbackText,
+    requestedFileName: fileName,
+    visited,
+  };
+}
+
+function createNestedParseContext(
+  context: ParseContext,
+  fallbackText?: string,
+): ParseContext {
+  return {
+    ...context,
+    depth: context.depth + 1,
+    fallbackText,
+  };
+}
+
+function getParsedType(
+  fileName: string,
+  typeName: string,
+  context = createParseContext(fileName, typeName),
+): string {
   if (typeName?.includes("|")) {
     return getUnionTypes(fileName, typeName);
   }
@@ -151,18 +215,17 @@ function getParsedType(fileName: string, typeName: string): string {
     return Object.values(groupedTypes[typeName])[0];
   }
 
-  // if typeName is an interface or type alias, try to resolve its structure
   if (typeChecker && typeScript) {
     const sourceFile = typeChecker.getProgram().getSourceFile(fileName);
     if (sourceFile) {
       const symbols = typeChecker.getSymbolsInScope(
         sourceFile,
-        typeScript.SymbolFlags.Type
+        typeScript.SymbolFlags.Type,
       );
       const symbol = symbols.find((s: any) => s.name === typeName);
       if (symbol) {
         const type = typeChecker.getDeclaredTypeOfSymbol(symbol);
-        return getFinalType(type);
+        return getFinalType(type, context);
       }
     }
   }
@@ -176,7 +239,9 @@ function getUnionTypes(fileName: string, typeName: string): string {
       ?.split("|")
       .map((part) => part.trim())
       .filter((part) => part.length > 0)
-      ?.map((part) => getParsedType(fileName, part))
+      ?.map((part) =>
+        getParsedType(fileName, part, createParseContext(fileName, part)),
+      )
       .join(" | ") || ""
   );
 }
@@ -187,27 +252,53 @@ function getObjectTypes(fileName: string, typeName: string): string {
       typeName
         ?.split(/[:{}]/)
         .map((part) => part.trim())
-        .filter((part) => part.length > 0)
+        .filter((part) => part.length > 0),
     ),
   ];
+
   parts.forEach((part) => {
-    // remove comments from object
     const cleanPart = part.replace(/\/\/.*|\/\*[\s\S]*?\*\//g, "");
-    typeName = typeName.replace(cleanPart, getParsedType(fileName, cleanPart));
+    typeName = typeName.replace(
+      cleanPart,
+      getParsedType(
+        fileName,
+        cleanPart,
+        createParseContext(fileName, cleanPart),
+      ),
+    );
   });
+
   return typeName;
 }
 
-function getFinalType(type: any): string {
-  if(isNpmType(type)) {
-    return typeChecker.typeToString(type);
+function getFinalType(type: any, context: ParseContext): string {
+  const fallbackText = getSafeTypeName(type, context.fallbackText);
+  if (shouldBailOnType(type, context)) {
+    return fallbackText;
   }
+
   if (type.isUnion()) {
-    return type.types.map(getFinalType).join(" | ");
+    return type.types
+      .map((memberType: any) =>
+        getFinalType(
+          memberType,
+          createNestedParseContext(context, fallbackText),
+        ),
+      )
+      .join(" | ");
   }
+
   if (type.isIntersection()) {
-    return type.types.map(getFinalType).join(" & ");
+    return type.types
+      .map((memberType: any) =>
+        getFinalType(
+          memberType,
+          createNestedParseContext(context, fallbackText),
+        ),
+      )
+      .join(" & ");
   }
+
   if (type.flags & typeScript.TypeFlags.String) {
     return "string";
   }
@@ -216,6 +307,9 @@ function getFinalType(type: any): string {
   }
   if (type.flags & typeScript.TypeFlags.Boolean) {
     return "boolean";
+  }
+  if (type.flags & typeScript.TypeFlags.BooleanLiteral) {
+    return String((type as any).intrinsicName);
   }
   if (type.flags & typeScript.TypeFlags.Unknown) {
     return "unknown";
@@ -256,82 +350,230 @@ function getFinalType(type: any): string {
   }
 
   if (type.flags & typeScript.TypeFlags.Enum) {
-    const enumType = type as ts.EnumType;
-    const enumMembers = typeChecker.getPropertiesOfType(enumType);
-    const enumValues = enumMembers.map((member: { name: any }) => member.name);
-    return enumValues.join(" | ");
+    const enumMembers = typeChecker.getPropertiesOfType(type as ts.EnumType);
+    return enumMembers
+      .map((member: { name: string }) => member.name)
+      .join(" | ");
   }
 
-  // Get properties if the type is an object
-  if (type.isClassOrInterface() || type.flags & typeScript.TypeFlags.Object) {
-    const properties = typeChecker.getPropertiesOfType(type);
-    const props = properties.map(
-      (prop: { valueDeclaration: any; name: any }) => {
-        const propType = typeChecker.getTypeOfSymbolAtLocation(
-          prop,
-          prop.valueDeclaration!
-        );
-        let typeStr: string;
-        let isOptional = false;
-        if (propType.isUnion && propType.isUnion()) {
-          const types = propType.types;
-          const hasUndefined = types.some((t: any) => t.flags & typeScript.TypeFlags.Undefined);
-          const nonUndefinedTypes = types.filter((t: any) => !(t.flags & typeScript.TypeFlags.Undefined));
-          if (hasUndefined) {
-            isOptional = true;
-          }
-          if (options.parseObjectTypes === "partial") {
-            // If all non-undefined types are primitives, show them, else use type name
-            const typeNames = nonUndefinedTypes.map((t: any) => typeChecker.typeToString(t));
-            if ((typeNames as string[]).every((tStr: string) => primitives.includes(tStr))) {
-              typeStr = typeNames.join(" | ");
-            } else {
-              typeStr = typeChecker.typeToString(propType);
-            }
-          } else {
-            typeStr = nonUndefinedTypes.map(getFinalType).join(" | ");
-          }
-        } else {
-          if (options.parseObjectTypes === "partial") {
-            const tStr = typeChecker.typeToString(propType);
-            if (primitives.includes(tStr)) {
-              typeStr = tStr;
-            } else {
-              // If it's an inline type (object literal), expand, else use type name
-              if (propType.objectFlags && propType.objectFlags & typeScript.ObjectFlags.Anonymous) {
-                typeStr = getFinalType(propType);
-              } else {
-                typeStr = tStr;
-              }
-            }
-          } else {
-            typeStr = getFinalType(propType);
-          }
-        }
-        if (!isOptional && typeStr.endsWith(' (optional)')) {
-          isOptional = true;
-          typeStr = typeStr.replace(' (optional)', '');
-        }
-        return `${prop.name}${isOptional ? '?' : ''}: ${typeStr}`;
-      }
+  if (typeChecker.isTupleType?.(type)) {
+    const tupleTypes = typeChecker.getTypeArguments(type as ts.TypeReference);
+    return `[${tupleTypes
+      .map((tupleType: any) =>
+        getFinalType(
+          tupleType,
+          createNestedParseContext(context, fallbackText),
+        ),
+      )
+      .join(", ")}]`;
+  }
+
+  if (typeChecker.isArrayType?.(type)) {
+    const [elementType] = typeChecker.getTypeArguments(
+      type as ts.TypeReference,
     );
+    if (!elementType) {
+      return `${fallbackText}[]`;
+    }
+
+    return `${getFinalType(
+      elementType,
+      createNestedParseContext(context, fallbackText),
+    )}[]`;
+  }
+
+  if (type.isClassOrInterface() || type.flags & typeScript.TypeFlags.Object) {
+    const trackableType = type as object;
+    context.visited.add(trackableType);
+
+    const properties = typeChecker.getPropertiesOfType(type);
+    if (properties.length > MAX_PARSE_PROPERTIES) {
+      context.visited.delete(trackableType);
+      logParseFailure(
+        type,
+        `type has ${properties.length} properties, which exceeds the limit of ${MAX_PARSE_PROPERTIES}`,
+        context,
+      );
+      return fallbackText;
+    }
+
+    const props = properties.map(
+      (prop: { valueDeclaration: any; name: string }) =>
+        getPropertyTypeText(prop, type, context, fallbackText),
+    );
+
+    context.visited.delete(trackableType);
     return `{ ${props.join(", ")} }`;
   }
 
-  return typeChecker.typeToString(type);
+  return fallbackText;
 }
 
-function isNpmType(type: ts.Type): boolean {
-  const symbol = type.getSymbol();
-  if (!symbol) return false;
+function getPropertyTypeText(
+  prop: { valueDeclaration: any; name: string; getDeclarations?: () => any[] },
+  parentType: ts.Type,
+  context: ParseContext,
+  fallbackText: string,
+) {
+  const declaration = prop.valueDeclaration || prop.getDeclarations?.()?.[0];
+  if (!declaration) {
+    logParseFailure(
+      parentType,
+      `property "${prop.name}" does not have a declaration that can be inspected`,
+      context,
+    );
+    return `${prop.name}: ${fallbackText}`;
+  }
 
+  const propType = typeChecker.getTypeOfSymbolAtLocation(prop, declaration);
+  const propFallbackText = getSafeTypeName(propType, prop.name);
+  let typeStr: string;
+  let isOptional = false;
+
+  if (propType.isUnion && propType.isUnion()) {
+    const types = propType.types;
+    const hasUndefined = types.some(
+      (t: any) => t.flags & typeScript.TypeFlags.Undefined,
+    );
+    const nonUndefinedTypes = types.filter(
+      (t: any) => !(t.flags & typeScript.TypeFlags.Undefined),
+    );
+
+    if (hasUndefined) {
+      isOptional = true;
+    }
+
+    if (options.parseObjectTypes === "partial") {
+      const typeNames = nonUndefinedTypes.map((t: any) => getSafeTypeName(t));
+      if (typeNames.every((tStr: string) => primitives.includes(tStr))) {
+        typeStr = typeNames.join(" | ");
+      } else {
+        typeStr = propFallbackText;
+      }
+    } else {
+      typeStr = nonUndefinedTypes
+        .map((memberType: any) =>
+          getFinalType(
+            memberType,
+            createNestedParseContext(
+              context,
+              getSafeTypeName(memberType, prop.name),
+            ),
+          ),
+        )
+        .join(" | ");
+    }
+  } else if (options.parseObjectTypes === "partial") {
+    if (primitives.includes(propFallbackText)) {
+      typeStr = propFallbackText;
+    } else if (
+      propType.objectFlags &&
+      propType.objectFlags & typeScript.ObjectFlags.Anonymous
+    ) {
+      typeStr = getFinalType(
+        propType,
+        createNestedParseContext(context, propFallbackText),
+      );
+    } else {
+      typeStr = propFallbackText;
+    }
+  } else {
+    typeStr = getFinalType(
+      propType,
+      createNestedParseContext(context, propFallbackText),
+    );
+  }
+
+  if (!isOptional && typeStr.endsWith(" (optional)")) {
+    isOptional = true;
+    typeStr = typeStr.replace(" (optional)", "");
+  }
+
+  return `${prop.name}${isOptional ? "?" : ""}: ${typeStr}`;
+}
+
+function shouldBailOnType(type: ts.Type, context: ParseContext): boolean {
+  if (context.depth >= MAX_PARSE_DEPTH) {
+    logParseFailure(
+      type,
+      `type expansion exceeded the maximum depth of ${MAX_PARSE_DEPTH}`,
+      context,
+    );
+    return true;
+  }
+
+  if (context.visited.has(type as object)) {
+    logParseFailure(type, "detected a recursive type reference", context);
+    return true;
+  }
+
+  return false;
+}
+
+function logParseFailure(type: ts.Type, reason: string, context: ParseContext) {
+  const typeName = getSafeTypeName(type, context.fallbackText);
+  const location = getTypeLocation(type, context.requestedFileName);
+  const cacheKey = `${typeName}|${location}|${reason}`;
+  if (loggedParseFailures.has(cacheKey)) {
+    return;
+  }
+
+  loggedParseFailures.add(cacheKey);
+  log.warn(
+    `[type-parser] - Skipped parsing type "${typeName}" at ${location}. Reason: ${reason}.`,
+  );
+}
+
+function getSafeTypeName(type: ts.Type, fallbackText?: string): string {
+  const symbol = getPrimaryTypeSymbol(type);
+  const symbolName = symbol?.getName();
+  if (symbolName && symbolName !== "__type") {
+    return symbolName;
+  }
+
+  const intrinsicName = (type as any).intrinsicName;
+  if (typeof intrinsicName === "string" && intrinsicName !== "__type") {
+    return intrinsicName;
+  }
+
+  return fallbackText || "unknown";
+}
+
+function getPrimaryTypeSymbol(type: ts.Type) {
+  const symbol = type.getSymbol?.();
+  if (symbol && isNodeModulesSymbol(symbol)) {
+    return symbol;
+  }
+
+  return type.aliasSymbol || symbol;
+}
+
+function getTypeLocation(type: ts.Type, fallbackFileName?: string): string {
+  const declaration = getPrimaryTypeSymbol(type)?.getDeclarations?.()?.[0];
+  if (declaration) {
+    const sourceFile = declaration.getSourceFile();
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+      declaration.getStart(),
+    );
+    return `${normalizeModulePath(sourceFile.fileName)}:${line + 1}:${character + 1}`;
+  }
+
+  if (fallbackFileName) {
+    return normalizeModulePath(fallbackFileName);
+  }
+
+  return "unknown location";
+}
+
+function isNodeModulesSymbol(symbol: ts.Symbol) {
   const declarations = symbol.getDeclarations();
-  if (!declarations || declarations.length === 0) return false;
+  if (!declarations || declarations.length === 0) {
+    return false;
+  }
 
-  return declarations.some((decl) => {
-    const sourceFile = decl.getSourceFile();
-    return sourceFile.fileName.includes('node_modules');
-  });
+  return declarations.some((decl) =>
+    decl.getSourceFile().fileName.includes("node_modules"),
+  );
 }
 
 // Visit each node in the source file
@@ -339,14 +581,18 @@ function visitNode(node: any) {
   if (
     typeScript.isTypeAliasDeclaration(node) ||
     typeScript.isEnumDeclaration(node) ||
-    (typeScript.isInterfaceDeclaration(node) && options.parseObjectTypes !== "none")
+    (typeScript.isInterfaceDeclaration(node) &&
+      options.parseObjectTypes !== "none")
   ) {
     const symbol = typeChecker.getSymbolAtLocation(node.name);
     if (symbol) {
       const type = typeChecker.getDeclaredTypeOfSymbol(symbol);
-      const finalType = getFinalType(type);
+      const finalType = getFinalType(
+        type,
+        createParseContext(currentFilename, node.name.text),
+      );
       log.log(
-        `Type alias '${node.name.text}' has final computed type: ${finalType}`
+        `Type alias '${node.name.text}' has final computed type: ${finalType}`,
       );
       aliasTypes[currentFilename][node.name.text] = finalType;
     }
@@ -387,7 +633,7 @@ function analyzePhase({ ts, node, moduleDoc, context }: any) {
 function getComponent(node: any, moduleDoc: any) {
   const className = node.name.getText();
   return moduleDoc.declarations.find(
-    (dec: Component) => dec.name === className
+    (dec: Component) => dec.name === className,
   ) as Component | undefined;
 }
 
@@ -398,12 +644,15 @@ function getTypedMembers(component: Component) {
       ...(component.members || []),
       ...(component.events || []),
     ] as any[]
-  ).filter((item) => item?.type || (options.parseParameters && item?.parameters?.length));
+  ).filter(
+    (item) =>
+      item?.type || (options.parseParameters && item?.parameters?.length),
+  );
 }
 
 function getTypeValue(item: any, context: any) {
   const importedType = context?.imports?.find(
-    (i: any) => i.name === item.type?.text
+    (i: any) => i.name === item.type?.text,
   );
 
   if (!importedType) {
@@ -411,14 +660,17 @@ function getTypeValue(item: any, context: any) {
   }
 
   const resolvedPath = getResolvedImportPath(currentFilename, importedType);
-
-  return getParsedType(resolvedPath, importedType.name);
+  return getParsedType(
+    resolvedPath,
+    importedType.name,
+    createParseContext(resolvedPath, importedType.name),
+  );
 }
 
 function getResolvedImportPath(importPath: string, importedType: any) {
   let resolvedPath = path.resolve(
     path.dirname(currentFilename),
-    importedType.importPath
+    importedType.importPath,
   );
 
   if (aliasTypes[resolvedPath]) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,6 +13,10 @@ export class Logger {
     console.log(color, message);
   }
 
+  warn(message: string) {
+    console.warn("\x1b[33m%s\x1b[0m", message);
+  }
+
   red(message: string) {
     this.log(message, "\x1b[31m%s\x1b[0m");
   }


### PR DESCRIPTION
## Summary
- add a patch changeset for the type parser updates
- fall back to the original type text and warn when recursive or oversized types cannot be expanded
- cover the new behavior in tests and document it in the README

## Testing
- pnpm lint
- pnpm test