### PR TITLE
Fix getTsProgram to resolve tsconfig extends chains

### DIFF
--- a/.changeset/twenty-jobs-yell.md
+++ b/.changeset/twenty-jobs-yell.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/type-parser": patch
+---
+
+Fix getTsProgram to resolve extends chains in tsconfig.json instead of silently falling back to default compiler options. Root files are now also resolved from the tsconfig's include/exclude, unioned with the caller-supplied globs.

--- a/src/__fixtures__/tsconfig-extends/base.tsconfig.json
+++ b/src/__fixtures__/tsconfig-extends/base.tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "strict": true
+  }
+}

--- a/src/__fixtures__/tsconfig-extends/sample.ts
+++ b/src/__fixtures__/tsconfig-extends/sample.ts
@@ -1,0 +1,1 @@
+export type Sample = "a" | "b" | "c";

--- a/src/__fixtures__/tsconfig-extends/tsconfig.json
+++ b/src/__fixtures__/tsconfig-extends/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./base.tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext"
+  },
+  "include": ["sample.ts"]
+}

--- a/src/__fixtures__/tsconfig-include-exclude/excluded.ts
+++ b/src/__fixtures__/tsconfig-include-exclude/excluded.ts
@@ -1,0 +1,1 @@
+export type Excluded = "x" | "y";

--- a/src/__fixtures__/tsconfig-include-exclude/included.ts
+++ b/src/__fixtures__/tsconfig-include-exclude/included.ts
@@ -1,0 +1,1 @@
+export type Included = "a" | "b";

--- a/src/__fixtures__/tsconfig-include-exclude/tsconfig.json
+++ b/src/__fixtures__/tsconfig-include-exclude/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES2018"
+  },
+  "include": ["included.ts"],
+  "exclude": ["excluded.ts"]
+}

--- a/src/__tests__/cem-plugin.test.ts
+++ b/src/__tests__/cem-plugin.test.ts
@@ -166,4 +166,45 @@ describe("type-parser", () => {
       /node_modules\/typescript\/lib|node_modules\\\\typescript\\\\lib/,
     );
   });
+
+  test("should resolve compilerOptions inherited via tsconfig `extends`", () => {
+    const extendingConfigDir = path.resolve(
+      "src/__fixtures__/tsconfig-extends",
+    );
+    const sampleFile = path.join(extendingConfigDir, "sample.ts");
+    const originalCwd = process.cwd();
+    process.chdir(extendingConfigDir);
+
+    try {
+      const program = getTsProgram(ts, [sampleFile], "tsconfig.json");
+
+      expect(program.getCompilerOptions().target).toEqual(
+        ts.ScriptTarget.ES2018,
+      );
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  test("should include files matched by tsconfig `include` and exclude files matched by `exclude`, even when not passed as globs", () => {
+    const configDir = path.resolve("src/__fixtures__/tsconfig-include-exclude");
+    const originalCwd = process.cwd();
+    process.chdir(configDir);
+
+    try {
+      const program = getTsProgram(ts, [], "tsconfig.json");
+      const sourceFileNames = program
+        .getSourceFiles()
+        .map((sourceFile) => sourceFile.fileName);
+
+      expect(sourceFileNames.some((name) => name.endsWith("included.ts"))).toBe(
+        true,
+      );
+      expect(sourceFileNames.some((name) => name.endsWith("excluded.ts"))).toBe(
+        false,
+      );
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
 });

--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -108,6 +108,9 @@ export function getTsProgram(
   log ??= new Logger(options.debug);
   resetParserState();
 
+  const diagnosticText = (diagnostic: ts.Diagnostic) =>
+    ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+
   const tsConfigFile = ts.findConfigFile(
     process.cwd(),
     ts.sys.fileExists,
@@ -118,16 +121,38 @@ export function getTsProgram(
       `[type-parser] - Could not find TypeScript config "${configName}".`,
     );
   }
-  const { config } = ts.readConfigFile(tsConfigFile, ts.sys.readFile);
-  const compilerOptions = ts.convertCompilerOptionsFromJson(
-    config.compilerOptions ?? {},
-    ".",
-  );
-  const program = ts.createProgram(globs, compilerOptions.options);
-  const exclusions =
-    config.exclude && config.exclude.length
-      ? [...config.exclude, "node_modules"]
-      : ["node_modules"];
+
+  const parseConfigHost: ts.ParseConfigFileHost = {
+    ...ts.sys,
+    onUnRecoverableConfigFileDiagnostic: (diagnostic: ts.Diagnostic) => {
+      throw new Error(
+        `[type-parser] - Could not parse TypeScript config "${configName}": ${diagnosticText(diagnostic)}`,
+      );
+    },
+  };
+
+  const parsedConfig = ts.getParsedCommandLineOfConfigFile(
+    tsConfigFile,
+    undefined,
+    parseConfigHost,
+  )!;
+
+  for (const diagnostic of parsedConfig.errors) {
+    const message = diagnosticText(diagnostic);
+    if (diagnostic.category === ts.DiagnosticCategory.Error) {
+      log.warn(`[type-parser] - TypeScript config error: ${message}`);
+    } else {
+      log.yellow(`[type-parser] - TypeScript config warning: ${message}`);
+    }
+  }
+
+  const rootFileNames = new Set<string>();
+  for (const fileName of [...parsedConfig.fileNames, ...globs]) {
+    rootFileNames.add(path.resolve(fileName));
+  }
+
+  const program = ts.createProgram([...rootFileNames], parsedConfig.options);
+  const exclusions = [...(parsedConfig.raw?.exclude ?? []), "node_modules"];
 
   typeScript = ts;
   typeChecker = program.getTypeChecker();


### PR DESCRIPTION
Replace ts.readConfigFile + ts.convertCompilerOptionsFromJson with ts.getParsedCommandLineOfConfigFile, the same API tsc itself uses to resolve compilerOptions. The old approach only parsed the raw JSON of the target config file, silently dropping any options inherited via extends (including array-form and node-module-specifier extends).

tsconfig include/exclude also feed into program root file resolution, unioned with caller-supplied globs, and parse diagnostics are surfaced via the existing logger instead of being silently discarded.