### PR TITLE
fix: resolve types for members declared on a Lit mixin

### DIFF
--- a/.changeset/mixin-member-resolution.md
+++ b/.changeset/mixin-member-resolution.md
@@ -1,0 +1,7 @@
+---
+"@wc-toolkit/type-parser": patch
+---
+
+Resolve `parsedType` for members declared on a Lit-style mixin.
+
+Declaration matching only recognised a manifest declaration when its name matched the class node exactly. A mixin factory's inner class (for example `WithFooClass`) never matched its emitted `kind: mixin` declaration (`WithFoo`), so the mixin's members kept their raw type text instead of an expanded union. Declaration matching now recognises `mixin` declarations by their factory name, and the existing node-based resolution runs on them.

--- a/src/__fixtures__/mixin/sized-mixin.ts
+++ b/src/__fixtures__/mixin/sized-mixin.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface SizeProps {
+  size: "small" | "medium" | "large";
+}
+
+type Constructor<T = object> = new (...args: any[]) => T;
+
+export const WithSize = <T extends Constructor<HTMLElement>>(superClass: T) => {
+  class WithSizeElement extends superClass {
+    size: SizeProps["size"];
+  }
+  return WithSizeElement;
+};

--- a/src/__fixtures__/mixin/tsconfig.json
+++ b/src/__fixtures__/mixin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/src/__tests__/mixin-resolution.test.ts
+++ b/src/__tests__/mixin-resolution.test.ts
@@ -1,0 +1,61 @@
+import path from "path";
+import ts from "typescript";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getTsProgram, typeParserPlugin } from "../cem-plugin.js";
+
+const fixtureDir = path.resolve("src/__fixtures__/mixin");
+const originalCwd = process.cwd();
+
+function findClass(sourceFile: ts.SourceFile, name: string) {
+  let match: ts.ClassDeclaration | undefined;
+  const visit = (node: ts.Node) => {
+    if (ts.isClassDeclaration(node) && node.name?.text === name) {
+      match = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return match;
+}
+
+describe("mixin member resolution", () => {
+  beforeEach(() => {
+    process.chdir(fixtureDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+  });
+
+  test("resolves members declared on a mixin's inner class", () => {
+    const plugin = typeParserPlugin({});
+    const program = getTsProgram(ts, ["sized-mixin.ts"], "tsconfig.json");
+    const sourceFile = program
+      .getSourceFiles()
+      .find((sf) => sf.fileName.endsWith("sized-mixin.ts"))!;
+    const classNode = findClass(sourceFile, "WithSizeElement")!;
+
+    const size: { type: { text: string }; parsedType?: { text: string } } = {
+      type: { text: 'SizeProps["size"]' },
+    };
+    const moduleDoc = {
+      path: sourceFile.fileName,
+      declarations: [
+        {
+          kind: "mixin",
+          name: "WithSize",
+          members: [{ name: "size", ...size }],
+        },
+      ],
+    };
+
+    plugin.analyzePhase({ ts, node: sourceFile, moduleDoc, context: {} });
+    plugin.analyzePhase({ ts, node: classNode, moduleDoc, context: {} });
+
+    const member = moduleDoc.declarations[0].members[0] as typeof size &
+      Record<string, unknown>;
+    expect(member.parsedType?.text).toEqual("'small' | 'medium' | 'large'");
+  });
+});

--- a/src/cem-plugin.ts
+++ b/src/cem-plugin.ts
@@ -796,9 +796,39 @@ function analyzePhase({ ts, node, moduleDoc }: any) {
 
 function getComponent(node: any, moduleDoc: any) {
   const className = node.name.getText();
-  return moduleDoc.declarations.find(
-    (dec: Component) => dec.name === className,
-  ) as Component | undefined;
+  const declarations = (moduleDoc.declarations ?? []) as Component[];
+
+  const factoryName = getEnclosingFactoryName(node);
+  if (factoryName) {
+    const mixin = declarations.find(
+      (dec) => (dec as any).kind === "mixin" && dec.name === factoryName,
+    );
+    if (mixin) {
+      return mixin as Component;
+    }
+  }
+
+  return declarations.find((dec) => dec.name === className) as
+    | Component
+    | undefined;
+}
+
+function getEnclosingFactoryName(node: any): string | undefined {
+  let current = node.parent;
+  while (current) {
+    if (typeScript.isVariableDeclaration(current) && current.name) {
+      return current.name.getText();
+    }
+    if (
+      (typeScript.isFunctionDeclaration(current) ||
+        typeScript.isFunctionExpression(current)) &&
+      current.name
+    ) {
+      return current.name.getText();
+    }
+    current = current.parent;
+  }
+  return undefined;
 }
 
 function getTypedMembers(component: Component) {


### PR DESCRIPTION
## Problem

`parsedType` is set on members declared directly on a component class, but not on members declared on a Lit-style mixin, which keep their raw type text (e.g. `SomeInterface['prop']`).

`getComponent` matches a declaration by exact class-node name. A mixin factory's inner class (`WithFooClass`) never matches its emitted `kind: mixin` declaration (`WithFoo`), so the mixin's members are skipped, even though they sit directly on that inner class node.

Sharing props through a mixin is a common Lit pattern, e.g. Spectrum's [`SizedMixin`](https://github.com/adobe/spectrum-web-components/blob/main/1st-gen/tools/base/src/sizedMixin.ts) adds a union-typed `size`.

## Fix

Match `kind: mixin` declarations by factory name so the existing resolution runs on their members. Member resolution itself is unchanged; propagating to consuming components stays out of scope (handled by the analyzer's own inheritance).
